### PR TITLE
Added options to verify() function

### DIFF
--- a/src/insight.js
+++ b/src/insight.js
@@ -138,11 +138,12 @@ class MultiInsight {
     this.insights = [];
 
     // Sets requests timeout (default = 10s)
-    let timeout = (options && options.hasOwnProperty('timeout')) ? options.timeout : 10;
+    const timeoutOptionSet = options && Object.prototype.hasOwnProperty.call(options, 'timeout');
+    const timeout = timeoutOptionSet ? options.timeout : 10;
 
     // We need at least 2 insight servers (for confirmation)
-    let urlsOptionSet = (options && options.hasOwnProperty('urls') && options.urls.length > 1);
-    let urls = urlsOptionSet ? options.urls : publicInsightUrls;
+    const urlsOptionSet = options && Object.prototype.hasOwnProperty.call(options, 'urls') && options.urls.length > 1;
+    const urls = urlsOptionSet ? options.urls : publicInsightUrls;
 
     urls.forEach(url => {
       this.insights.push(new Insight(url, timeout));

--- a/src/insight.js
+++ b/src/insight.js
@@ -114,7 +114,7 @@ class Insight {
   }
 }
 
-const urls = [
+const publicInsightUrls = [
   'https://www.localbitcoinschain.com/api',
   'https://search.bitaccess.co/insight-api',
   'https://insight.bitpay.com/api',
@@ -127,7 +127,7 @@ class MultiInsight {
 
   constructor() {
     this.insights = [];
-    urls.forEach(url => {
+    publicInsightUrls.forEach(url => {
       this.insights.push(new Insight(url));
     });
   }

--- a/src/insight.js
+++ b/src/insight.js
@@ -16,10 +16,12 @@ class Insight {
 
   /**
    * Create a RemoteCalendar.
+   * @param {int} timeout - timeout (in seconds) used for calls to insight servers
    */
-  constructor(url) {
+  constructor(url, timeout) {
     this.urlBlockindex = url + '/block-index';
     this.urlBlock = url + '/block';
+    this.timeout = timeout * 1000;
 
     // this.urlBlockindex = 'https://search.bitaccess.co/insight-api/block-index';
     // this.urlBlock = 'https://search.bitaccess.co/insight-api/block';
@@ -55,7 +57,8 @@ class Insight {
         'User-Agent': 'javascript-opentimestamps',
         'Content-Type': 'application/x-www-form-urlencoded'
       },
-      json: true
+      json: true,
+      timeout: this.timeout
     };
 
     return new Promise((resolve, reject) => {
@@ -92,7 +95,8 @@ class Insight {
         'User-Agent': 'javascript-opentimestamps',
         'Content-Type': 'application/x-www-form-urlencoded'
       },
-      json: true
+      json: true,
+      timeout: this.timeout
     };
 
     return new Promise((resolve, reject) => {
@@ -125,10 +129,23 @@ const publicInsightUrls = [
 
 class MultiInsight {
 
-  constructor() {
+  /** Constructor
+   * @param {object} options - Options
+   *    urls: array of insight server urls
+   *    timeout: timeout(in seconds) used for calls to insight servers
+   */
+  constructor(options) {
     this.insights = [];
-    publicInsightUrls.forEach(url => {
-      this.insights.push(new Insight(url));
+
+    // Sets requests timeout (default = 10s)
+    let timeout = (options && options.hasOwnProperty('timeout')) ? options.timeout : 10;
+
+    // We need at least 2 insight servers (for confirmation)
+    let urlsOptionSet = (options && options.hasOwnProperty('urls') && options.urls.length > 1);
+    let urls = urlsOptionSet ? options.urls : publicInsightUrls;
+
+    urls.forEach(url => {
+      this.insights.push(new Insight(url, timeout));
     });
   }
 

--- a/src/open-timestamps.js
+++ b/src/open-timestamps.js
@@ -235,7 +235,7 @@ module.exports = {
    * @exports OpenTimestamps/verify
    * @param {DetachedTimestampFile} detachedStamped - The detached of stamped file.
    * @param {DetachedTimestampFile} detachedOriginal - The detached of original file.
-   * @param {Object} options - 
+   * @param {Object} options -
    *    insight.urls: array of insight server urls
    *    insight.timeout: timeout (in seconds) used for calls to insight servers
    */
@@ -278,7 +278,7 @@ module.exports = {
 
   /** Verify a timestamp.
    * @param {Timestamp} timestamp - The timestamp.
-   * @param {Object} options - 
+   * @param {Object} options -
    *    insight.urls: array of insight server urls
    *    insight.timeout: timeout (in seconds) used for calls to insight servers
    * @return {int} unix timestamp if verified, undefined otherwise.
@@ -292,7 +292,8 @@ module.exports = {
         function liteVerify() {
           // There is no local node available or is turned of
           // Request to insight
-          const insightOptions = (options && options.hasOwnProperty('insight')) ? options.insight : null;
+          const insightOptionSet = options && Object.prototype.hasOwnProperty.call(options, 'insight');
+          const insightOptions = insightOptionSet ? options.insight : null;
           const insight = new Insight.MultiInsight(insightOptions);
           insight.blockhash(attestation.height).then(blockHash => {
             console.log('Lite-client verification, assuming block ' + blockHash + ' is valid');

--- a/test/open-timestamps.js
+++ b/test/open-timestamps.js
@@ -315,9 +315,9 @@ test('OpenTimestamps.verify()', assert => {
       ]
     }
   };
-  OpenTimestamps.verify(detachedOts, detached, options).then(result => {
-    assert.fail();
-  }).catch(err => {
+  OpenTimestamps.verify(detachedOts, detached, options).then(() => {
+    assert.fail('Unable to reach the server (bad insight url)');
+  }).catch(() => {
     assert.true(true);
     assert.end();
   });
@@ -344,11 +344,11 @@ test('OpenTimestamps.verify()', assert => {
 });
 
 test('OpenTimestamps.verify()', assert => {
-  // Test options with timeout of 5s
+  // Test options with timeout of 20s
   const detached = DetachedTimestampFile.fromBytes(new Ops.OpSHA256(), new Context.StreamDeserialization(helloworld));
   const detachedOts = DetachedTimestampFile.deserialize(new Context.StreamDeserialization(helloworldOts));
   const options = {
-    insight: {timeout: 5}
+    insight: {timeout: 20}
   };
   OpenTimestamps.verify(detachedOts, detached, options).then(result => {
     assert.true(result !== undefined);

--- a/test/open-timestamps.js
+++ b/test/open-timestamps.js
@@ -282,6 +282,83 @@ test('OpenTimestamps.verify()', assert => {
   });
 });
 
+test('OpenTimestamps.verify()', assert => {
+  // Test options with 2 insight urls
+  const detached = DetachedTimestampFile.fromBytes(new Ops.OpSHA256(), new Context.StreamDeserialization(helloworld));
+  const detachedOts = DetachedTimestampFile.deserialize(new Context.StreamDeserialization(helloworldOts));
+  const options = {
+    insight: {
+      urls: [
+        'https://insight.bitpay.com/api',
+        'https://btc-bitcore1.trezor.io/api'
+      ]
+    }
+  };
+  OpenTimestamps.verify(detachedOts, detached, options).then(result => {
+    assert.true(result !== undefined);
+    assert.equal(result, 1432827678);
+    assert.end();
+  }).catch(err => {
+    assert.fail('err=' + err);
+  });
+});
+
+test('OpenTimestamps.verify()', assert => {
+  // Test options with 2 bad insight urls (it should fail)
+  const detached = DetachedTimestampFile.fromBytes(new Ops.OpSHA256(), new Context.StreamDeserialization(helloworld));
+  const detachedOts = DetachedTimestampFile.deserialize(new Context.StreamDeserialization(helloworldOts));
+  const options = {
+    insight: {
+      urls: [
+        'https://badinsight1.bitpay.com/api',
+        'https://badinsight2.bitpay.com/api'
+      ]
+    }
+  };
+  OpenTimestamps.verify(detachedOts, detached, options).then(result => {
+    assert.fail();
+  }).catch(err => {
+    assert.true(true);
+    assert.end();
+  });
+});
+
+test('OpenTimestamps.verify()', assert => {
+  // Test options with 1 insight url (it should fallback to default list)
+  const detached = DetachedTimestampFile.fromBytes(new Ops.OpSHA256(), new Context.StreamDeserialization(helloworld));
+  const detachedOts = DetachedTimestampFile.deserialize(new Context.StreamDeserialization(helloworldOts));
+  const options = {
+    insight: {
+      urls: [
+        'https://insight.bitpay.com/api'
+      ]
+    }
+  };
+  OpenTimestamps.verify(detachedOts, detached, options).then(result => {
+    assert.true(result !== undefined);
+    assert.equal(result, 1432827678);
+    assert.end();
+  }).catch(err => {
+    assert.fail('err=' + err);
+  });
+});
+
+test('OpenTimestamps.verify()', assert => {
+  // Test options with timeout of 5s
+  const detached = DetachedTimestampFile.fromBytes(new Ops.OpSHA256(), new Context.StreamDeserialization(helloworld));
+  const detachedOts = DetachedTimestampFile.deserialize(new Context.StreamDeserialization(helloworldOts));
+  const options = {
+    insight: {timeout: 5}
+  };
+  OpenTimestamps.verify(detachedOts, detached, options).then(result => {
+    assert.true(result !== undefined);
+    assert.equal(result, 1432827678);
+    assert.end();
+  }).catch(err => {
+    assert.fail('err=' + err);
+  });
+});
+
 // UPGRADE TESTS
 
 test('OpenTimestamps.upgrade()', assert => {


### PR DESCRIPTION
PR related to issue #9 

Added options parameters to verify() function:

options.insight.urls - {string[]} - array of insight server urls
    more than 2 urls are required, otherwise fallback to default list

options.insight.timeout - {integer} - timeout for requests sent to insight servers
    timeout expressed in seconds
