### PR TITLE
Test: pass options to MultiInsight

### DIFF
--- a/test/insight.js
+++ b/test/insight.js
@@ -28,3 +28,23 @@ test('MultiInsight block test', assert => {
     assert.fail('err=' + err)
   })
 })
+
+test('Pass options', assert => {
+  const options = {
+    timeout: 30,
+    urls: [
+      'https://www.localbitcoinschain.com/api',
+      'https://search.bitaccess.co/insight-api',
+      'https://insight.bitpay.com/api',
+      'https://blockexplorer.com/api'
+    ]
+  }
+  const m = new Insight.MultiInsight(options)
+  const resultPromise = m.block('000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f')
+  resultPromise.then(result => {
+    assert.equals(result.merkleroot, '4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b', 'genesis block merkle root matches')
+    assert.end()
+  }).catch(err => {
+    assert.fail('err=' + err)
+  })
+})


### PR DESCRIPTION
Add test to pass options parameter (timeout & urls) to MultiInsight, explained in #29