### PR TITLE
chore: reduce reflected insight stderr messages to 100 chars.

### DIFF
--- a/src/insight.js
+++ b/src/insight.js
@@ -121,12 +121,13 @@ class Insight {
 
 const publicInsightUrls = {}
 publicInsightUrls.bitcoin = [
-  'https://www.localbitcoinschain.com/api',
-  'https://search.bitaccess.co/insight-api',
+//  'https://www.localbitcoinschain.com/api',  // gives 502 - "lots of HTML code"
+//  'https://search.bitaccess.co/insight-api',   // gives 400 - "Block height out of range. Code:-8"
   'https://insight.bitpay.com/api',
   'https://btc-bitcore1.trezor.io/api',
   'https://btc-bitcore4.trezor.io/api',
-  'https://blockexplorer.com/api'
+  'https://blockexplorer.com/api',
+  'https://bitcore.schmoock.net/insight-api'
 ]
 publicInsightUrls.litecoin = [
   'https://ltc-bitcore1.trezor.io/api',

--- a/src/insight.js
+++ b/src/insight.js
@@ -73,7 +73,7 @@ class Insight {
           resolve(body.blockHash)
         })
         .catch(err => {
-          console.error('Insight response error: ' + err)
+          console.error('Insight response error: ' + err.toString().substr(0, 100))
           reject(err)
         })
     })
@@ -112,7 +112,7 @@ class Insight {
           resolve({merkleroot: body.merkleroot, time: body.time})
         })
         .catch(err => {
-          console.error('Insight response error: ' + err)
+          console.error('Insight response error: ' + err.toString().substr(0, 100))
           reject(err)
         })
     })


### PR DESCRIPTION
First step is to prevent excessive HTTP 502 Cloudflare HTML error massages from filling up stderr.