### PR TITLE
Convert calendar console logs to debug logs

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "bitcore-message": "^1.0.4",
     "bytebuffer": "^5.0.1",
     "commander": "^2.20.0",
+    "debug": "^4.1.1",
     "fs": "0.0.1-security",
     "keccak": "^1.4.0",
     "minimatch": "^3.0.4",

--- a/src/open-timestamps.js
+++ b/src/open-timestamps.js
@@ -19,6 +19,7 @@ const Notary = require('./notary.js')
 const Esplora = require('./esplora.js')
 const Merkle = require('./merkle.js')
 const Bitcoin = require('./bitcoin.js')
+const debug = require('debug')('opentimestamps')
 
 module.exports = {
 
@@ -176,7 +177,7 @@ module.exports = {
       calendars.forEach(calendar => {
         const remote = new Calendar.RemoteCalendar(calendar)
         res.push(remote.submit(timestamp.msg))
-        console.log('Submitting to remote calendar ' + calendar)
+        debug('Submitting to remote calendar ' + calendar)
       })
     }
     if (privateCalendars) {


### PR DESCRIPTION
When using this library in applications, it annoyingly litters stdout
with debug info.

Change the "Submitting to remote calendar" console logs to debug logs.
To enable these logs, pass DEBUG=opentimestamps before running the
application.

Now when you use the client for stamping you should see this:

    $ node ots-cli.js stamp LICENSE
    The timestamp proof 'LICENSE.ots' has been created!

With DEBUG=opentimestamps you see this:

    $ DEBUG=opentimestamps node ots-cli.js stamp LICENSE
      opentimestamps Submitting to remote calendar https://a.pool.opentimestamps.org +0ms
      opentimestamps Submitting to remote calendar https://b.pool.opentimestamps.org +1ms
      opentimestamps Submitting to remote calendar https://a.pool.eternitywall.com +0ms
      opentimestamps Submitting to remote calendar https://ots.btc.catallaxy.com +1ms
    The timestamp proof 'LICENSE.ots' already exists

I've left the other logs for now, as I do not see them when using this
for timestamping in other applications, and they are probably useful
when using ots-cli.js