### PR TITLE
Adding Prune command

### DIFF
--- a/ots-cli.js
+++ b/ots-cli.js
@@ -44,18 +44,18 @@ const infoCommand = program
     info(file, options)
   })
 
-  const pruneCommand = program
+const pruneCommand = program
   .command('prune [FILE_OTS]')
   .alias('p')
   .description('Prune timestamp.')
   .action((file, options) => {
     isExecuted = true
     if (!file) {
-      console.log(prugneCommand.helpInformation())
+      console.log(pruneCommand.helpInformation())
       return
     }
     options = parseCommon(options)
-    prune(file,options)
+    prune(file, options)
   })
 
 const stampCommand = program
@@ -199,7 +199,7 @@ function info (argsFileOts, options) {
   })
 }
 
-function prune(argsFileOts,options) {
+function prune (argsFileOts, options) {
   const files = []
   files.push(Utils.readFilePromise(argsFileOts, null))
   Promise.all(files).then(values => {
@@ -220,12 +220,13 @@ function prune(argsFileOts,options) {
     }
     // Opentimestamps prune
     OpenTimestamps.prune(detachedOts, options)
-      .then(function(results){
-        fs.renameSync(argsFileOts,argsFileOts+".bak")
-        fs.writeFile(argsFileOts, Buffer.from(detachedOts.serializeToBytes()), 'binary',err =>{})
-        console.log("Recepit Pruned")
+      .then(function (results) {
+        // Backup the file and create the new receipt
+        fs.renameSync(argsFileOts, argsFileOts + '.bak')
+        fs.writeFile(argsFileOts, Buffer.from(detachedOts.serializeToBytes()), 'binary', err => { if (err) { console.log('Error in serialization') } })
+        console.log('Recepit Pruned')
       }).catch(err => {
-        console.log("Is not possible to prune due to " + err)
+        console.log('Is not possible to prune due to ' + err)
       })
   }).catch(err => {
     if (err.code === 'ENOENT') {

--- a/src/calendar.js
+++ b/src/calendar.js
@@ -20,6 +20,7 @@ const Message = require('bitcore-message')
 const Utils = require('./utils.js')
 const Context = require('./context.js')
 const Timestamp = require('./timestamp.js')
+const { URL } = require('url')
 
 /* Errors */
 const CommitmentNotFoundError = Error.extend('CommitmentNotFoundError')

--- a/src/open-timestamps.js
+++ b/src/open-timestamps.js
@@ -97,33 +97,37 @@ module.exports = {
     return JSON.stringify(json)
   },
 
-  
-  pruneTree(timestamp) {
-    let prun = timestamp.attestations.length == 0
+  /*
+  * Delete all the dead branches
+  */
+  pruneTree (timestamp) {
+    let prun = timestamp.attestations.length === 0
     let changed = false
 
-    for(const element of timestamp.ops) {
+    for (const element of timestamp.ops) {
       var result = this.pruneTree(element[1])
-      var stamp_prunable = result.prunable
-      var stamp_changed = result.change
-      changed = changed || stamp_changed || stamp_prunable
-      if(stamp_prunable) {
+      var stampPrunable = result.prunable
+      var stampChanged = result.change
+      changed = changed || stampChanged || stampPrunable
+      if (stampPrunable) {
         timestamp.ops.delete(element[0])
       } else {
         prun = false
       }
     }
-    return {prunable : prun, change: changed}
-
+    return { prunable: prun, change: changed }
   },
 
-  discard_attestation(timestamp, saveOnly) {
+  /*
+  * Delete all the leaves which didn't match the height passed
+  */
+  discard_attestation (timestamp, heightToKeep) {
     timestamp.getAttestations().forEach(opStamp => {
-      if(!(opStamp instanceof Notary.BitcoinBlockHeaderAttestation && opStamp.height == saveOnly) ) {
-        timestamp.attestations.splice(timestamp.attestations.indexOf(opStamp),1)
+      if (!(opStamp instanceof Notary.BitcoinBlockHeaderAttestation && opStamp.height === heightToKeep)) {
+        timestamp.attestations.splice(timestamp.attestations.indexOf(opStamp), 1)
       }
     })
-    var iter =  timestamp.ops.values()
+    var iter = timestamp.ops.values()
     let res = iter.next()
     while (!res.done) {
       this.discard_attestation(res.value)
@@ -131,32 +135,31 @@ module.exports = {
     }
   },
   /**
-   * Prune a timestamp dropping the redundant data included in the ots receipt, storing only the linear proof from the file hash to the best attestation. 
+   * Prune a timestamp dropping the redundant data included in the ots receipt, storing only the linear proof from the file hash to the best attestation.
+   * @exports OpenTimestamps/prune
+   * @param {DetachedTimestampFile[]} detaches - The array of detached file to stamp; input/output parameter.
+   * @param {Object} options - The option arguments. Not used yet
   */
-  prune(detaches, options = {}) {
+  prune (detaches, options = {}) {
     let prunable = false
-    let maxHead = 0;
+    let maxHead = 0
 
-    if(detaches.timestamp.getAttestations().length <= 1) { 
+    if (detaches.timestamp.getAttestations().length <= 1) {
       return new Promise((resolve, reject) => { reject(new Error('Just one attestation founded')) })
-    } 
+    }
     detaches.timestamp.getAttestations().forEach(subStamp => {
-      if(subStamp instanceof Notary.BitcoinBlockHeaderAttestation) {
-        prunable = true;
-        maxHead = (maxHead < subStamp.height)? subStamp.height : maxHead 
+      if (subStamp instanceof Notary.BitcoinBlockHeaderAttestation) {
+        prunable = true
+        maxHead = (maxHead < subStamp.height) ? subStamp.height : maxHead
       }
     })
-    console.log(maxHead)
-    if(prunable) {
+    if (prunable) {
       this.discard_attestation(detaches.timestamp, maxHead)
       this.pruneTree(detaches.timestamp)
-      console.log(detaches.timestamp.strTree())
-      process.exit(1)
       return new Promise((resolve, reject) => { resolve(detaches) })
     } else {
       return new Promise((resolve, reject) => { reject(new Error('There are no Bitcoin Attestation in the file')) })
     }
-  
   },
 
   /**

--- a/src/timestamp.js
+++ b/src/timestamp.js
@@ -84,16 +84,6 @@ class Timestamp {
     return self
   }
 
-  delAttestation(clone_to_del) {
-    console.log("Recieved " + clone_to_del)
-    console.log(this.attestations)
-    var index = this.attestations.indexOf(clone_to_del)
-    console.log("I'm going to delete " + index)
-    this.attestations.splice(index,1)
-    console.log("Done!  " +  this.attestations)
-  }
-
-
   /**
    * Create a Serialize object.
    * @param {StreamSerializationContext} ctx - The stream serialization context.

--- a/test/calendar.js
+++ b/test/calendar.js
@@ -1,6 +1,7 @@
 const test = require('tape')
 const Calendar = require('../src/calendar.js')
 const Utils = require('../src/utils.js')
+const { URL } = require('url')
 
 test('Calendar.privateSubmit()', assert => {
   const digest = Array.from(Utils.randBytes(32))


### PR DESCRIPTION
First draft of the prune command asked in [here](https://github.com/opentimestamps/opentimestamps-client/issues/88), right now the command is pretty poor:
- No options available
- Prune if there is at least one bitcoin attestation, deleting all others attestations in the timestamp
-  No verification of the attestations before the prune.

The branch is not meant to be merged as it is but as a starting point to add the new feature. 