### PR TITLE
Update open-timestamps.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,10 @@ const file = Buffer.from('5468697320646f63756d656e742069732074696d657374616d7065
 const fileOts = Buffer.from('004f70656e54696d657374616d7073000050726f6f6600bf89e2e884e89294010832bb24ab386bef01c0656944ecafa2dbb1e4162ced385754419467f9fb6f4d97f010c7c118043ce37d45f1ab81d3cd9dc9aa08fff0109b01031328e457c754a860bc5bc567ab08f02012dbcf25d46d7f01c4bd7c7ebdcd2080974b83a9198bc63cdb23f69c817f110508f0203c6274f7a67007de279fb68938e5549f462043570ccdbc17ba43e632a772d43208f1045ab0daf9f008ad9722b721af69e80083dfe30d2ef90c8e292868747470733a2f2f66696e6e65792e63616c656e6461722e657465726e69747977616c6c2e636f6df010dfd289ba718b4f30bb78191936c762a508f02026503e60c641473ec6f833953d04f7c8a65c5059a44a7e8c01c8cb9fed2ac2b308f1045ab0dafaf008c0c7948d8d5b64cf0083dfe30d2ef90c8e232268747470733a2f2f6c74632e63616c656e6461722e636174616c6c6178792e636f6d','hex');
 const detached = OpenTimestamps.DetachedTimestampFile.fromBytes(new OpenTimestamps.Ops.OpSHA256(), file);
 const detachedOts = OpenTimestamps.DetachedTimestampFile.deserialize(fileOts);
-OpenTimestamps.verify(detachedOts,detached).then(verifyResult => {
+// options let you ignore local bitcoin node verification
+let options = {};
+options.ignoreBitcoinNode = true;
+OpenTimestamps.verify(detachedOts,detached,options).then(verifyResult => {
   // return an object containing timestamp and height for every attestation if verified, undefined otherwise.
   console.log(verifyResult);
   // prints:

--- a/src/open-timestamps.js
+++ b/src/open-timestamps.js
@@ -233,7 +233,7 @@ module.exports = {
    * @param {Object} options.esplora - The options for esplora explorer.
    * @param {String[]} options.calendars - Override calendars in timestamp.
    * @param {UrlWhitelist} options.whitelist - Remote calendar whitelist.
-   * @param {Boolean} options.ignore_bitcoin_node - Ignore verification with bitcoin node, only with explorer.
+   * @param {Boolean} options.ignoreBitcoinNode - Ignore verification with bitcoin node, only with explorer.
    * @return {Promise<HashMap<String,Object>,Error>} if resolve return list of verified attestations indexed by chain.
    */
   verify (detachedStamped, detachedOriginal, options) {
@@ -255,7 +255,7 @@ module.exports = {
    * @param {Timestamp} timestamp - The timestamp.
    * @param {Object} options - The option arguments.
    * @param {Object} options.esplora - The options for esplora explorer.
-   * @param {Boolean} options.ignore_bitcoin_node - Ignore verification with bitcoin node, only with explorer.
+   * @param {Boolean} options.ignoreBitcoinNode - Ignore verification with bitcoin node, only with explorer.
    * @return {Promise<HashMap<String,Object>,Error>} if resolve return list of verified attestations indexed by chain.
    *    timestamp: unix timestamp
    *    height: block height of the min attestation
@@ -304,7 +304,7 @@ module.exports = {
    * @param {byte[]} msg - The digest to verify.
    * @param {Object} options - The option arguments.
    * @param {Object} options.esplora - The options for esplora explorer.
-   * @param {Boolean} options.ignore_bitcoin_node - Ignore verification with bitcoin node, only with explorer.
+   * @param {Boolean} options.ignoreBitcoinNode - Ignore verification with bitcoin node, only with explorer.
    * @return {Promise<Object,Error>} if resolve return verified attestations parameters
    *    chain: the chain type
    *    attestedTime: unix timestamp fo the block


### PR DESCRIPTION
The comment indicate options.ignore_bitcoin_node but the function expect and use options.ignoreBitcoinNode .
I can change the line 335 instead of the comments.