### PR TITLE
Explicit URL import on calendar

### DIFF
--- a/src/calendar.js
+++ b/src/calendar.js
@@ -7,6 +7,7 @@
  * @license LPGL3
  */
 
+const URL = require('url').URL
 const requestPromise = require('request-promise')
 const minimatch = require('minimatch')
 require('./extend-error.js')


### PR DESCRIPTION
Some old nodejs/browser could not include URL as global variable, as node >= 10 does. So make the URL import explicit.

Close https://github.com/opentimestamps/javascript-opentimestamps/issues/74