### PR TITLE
Renamed getLenght() to getLength()

### DIFF
--- a/src/context.js
+++ b/src/context.js
@@ -154,7 +154,7 @@ class StreamSerializationContext {
     return output
   }
 
-  getLenght () {
+  getLength () {
     return this.length
   }
 


### PR DESCRIPTION
This method is never actually called, so correcting the spelling should be harmless.