### PR TITLE
Fix gulp command

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ npm install --dev
 then run the gulp process
 
 ```
-gulp
+npx gulp
 ```
 
 include the result `/dist/opentimestamps.min.js` in your page


### PR DESCRIPTION
Users might not have `gulp` installed globally. `npx gulp` is better here because `npm install --dev` has already installed `gulp` in this package. 