### PR TITLE
emove main from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "opentimestamps",
   "version": "0.4.9",
   "description": "JS Porting of OpenTimestamps",
-  "main": "open-timestamps.js",
   "dependencies": {
     "bitcore-lib": "^8.14.4",
     "bytebuffer": "^5.0.1",


### PR DESCRIPTION
The `package.json` file includes a main file that does not exists in root. When trying to use this library as a dependency the build fails because of this.

`index.js` is the default value when it's not specified so removing it fix it